### PR TITLE
feat: add kubectl --context flag to 'apply'

### DIFF
--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -16,8 +16,11 @@ function createApplier(opts: ApplyOpts) {
 export function applyCommand(global: Command<GlobalOpts>): Command<GlobalOpts> {
   return global.command("apply")
     .description("apply resources for the given environment")
-    .option(" -b, --bootstrap [bootstrap:boolean]", "also apply bootstrap", {
+    .option("-b, --bootstrap [bootstrap:boolean]", "also apply bootstrap", {
       default: false,
+    })
+    .option("-C, --context <context:string>", "use kubectl context", {
+      default: "",
     })
     .action(handler)
     .reset();

--- a/src/internal/k8s.ts
+++ b/src/internal/k8s.ts
@@ -61,7 +61,7 @@ export class Applier {
     if (context) {
       args.unshift(`--context=${context}`);
     }
-    
+
     await new CommandBuilder()
       .command([
         cmd,

--- a/src/internal/k8s.ts
+++ b/src/internal/k8s.ts
@@ -50,9 +50,7 @@ export class Applier {
   }
 
   async applyKustomize(path: string) {
-    const { env } = this.config;
-
-    await $`kubectl --context=${env} apply --wait -k ${path}`
+    await $`kubectl apply --wait -k ${path}`
       .printCommand();
 
     await this.verifyKustomize(path);

--- a/test/cmd/apply.test.ts
+++ b/test/cmd/apply.test.ts
@@ -51,9 +51,15 @@ describe("cmd/apply", () => {
       expect(opt?.aliases).to.deep.equal(["b"]);
       expect(opt?.typeDefinition).to.equal("[bootstrap:boolean]");
       expect(opt?.default).to.be.false();
+
+      opt = apply?.getOption("context");
+      expect(opt).to.exist();
+      expect(opt?.aliases).to.deep.equal(["C"]);
+      expect(opt?.typeDefinition).to.equal("<context:string>");
+      expect(opt?.default).to.equal("");
     });
 
-    it("calls the handler on parse (no bootstrapping)", async () => {
+    it("calls the handler on parse", async () => {
       const cmd = applyCommand(global);
       await cmd.parse([
         "apply",
@@ -66,6 +72,7 @@ describe("cmd/apply", () => {
           env: "testing",
           identityDir: Deno.env.get("DEPLOYER_IDENTITY_DIR") || Deno.cwd(),
           bootstrap: false,
+          context: "",
         },
       ]);
       expect(spyExecute).to.have.been.called(1);
@@ -84,6 +91,7 @@ describe("cmd/apply", () => {
           env: "testing",
           identityDir: Deno.env.get("DEPLOYER_IDENTITY_DIR") || Deno.cwd(),
           bootstrap: true,
+          context: "",
         },
       ]);
       expect(spyExecute).to.have.been.called(1);
@@ -103,6 +111,27 @@ describe("cmd/apply", () => {
           env: "testing",
           identityDir: "/devel/identity",
           bootstrap: false,
+          context: "",
+        },
+      ]);
+      expect(spyExecute).to.have.been.called(1);
+    });
+    it("calls the handler on parse (with context)", async () => {
+      const cmd = applyCommand(global);
+      await cmd.parse([
+        "apply",
+        "--env",
+        "testing",
+        "--context",
+        "testing",
+      ]);
+
+      expect(spyCreateApply).to.have.been.deep.calledWith([
+        {
+          env: "testing",
+          identityDir: Deno.env.get("DEPLOYER_IDENTITY_DIR") || Deno.cwd(),
+          bootstrap: false,
+          context: "testing",
         },
       ]);
       expect(spyExecute).to.have.been.called(1);

--- a/test/internal/k8s.test.ts
+++ b/test/internal/k8s.test.ts
@@ -185,11 +185,41 @@ describe("internal/k8s", () => {
           spyVerifyKustomize.restore();
       });
 
-      it("calls customize for the given path", async () => {
+      it("calls customize for the given path (no context)", async () => {
         const applier = new Applier(opts);
 
         spyCommandBuilder.apply({});
         await applier.applyKustomize("k8s/env/testing");
+        expect(spyCommandBuilder.command).to.have.been.deep.calledWith([
+          [
+            "kubectl",
+            "apply",
+            "--wait",
+            '--kustomize="k8s/env/testing"',
+          ],
+        ]);
+        expect(spyCommandBuilder.stub).to.have.been.deep.called(1);
+        expect(spyVerifyKustomize).to.have.been.deep.calledWith([
+          "k8s/env/testing",
+        ]);
+      });
+      it("calls customize for the given path (with context)", async () => {
+        const applier = new Applier({
+          ...opts,
+          context: "testing",
+        });
+
+        spyCommandBuilder.apply({});
+        await applier.applyKustomize("k8s/env/testing");
+        expect(spyCommandBuilder.command).to.have.been.deep.calledWith([
+          [
+            "kubectl",
+            "--context=testing",
+            "apply",
+            "--wait",
+            '--kustomize="k8s/env/testing"',
+          ],
+        ]);
         expect(spyCommandBuilder.stub).to.have.been.deep.called(1);
         expect(spyVerifyKustomize).to.have.been.deep.calledWith([
           "k8s/env/testing",

--- a/test/mocked.ts
+++ b/test/mocked.ts
@@ -17,6 +17,7 @@ export interface CommandBuilderStubberOpts {
 
 export class CommandBuilderStubber {
   #stubber?: mock.Spy;
+  #command?: mock.Spy;
 
   constructor() {
     this.#stubber = undefined;
@@ -24,6 +25,10 @@ export class CommandBuilderStubber {
 
   get stub() {
     return this.#stubber;
+  }
+
+  get command() {
+    return this.#command;
   }
 
   apply(opts: CommandBuilderStubberOpts) {
@@ -38,6 +43,9 @@ export class CommandBuilderStubber {
       combined.grow(opts.err.byteLength);
       combined.writeSync(opts.err);
     }
+
+    this.#command = mock.spy(CommandBuilder.prototype,
+      "command");
 
     const result = new CommandResult(
       opts.code ?? 0,
@@ -55,6 +63,9 @@ export class CommandBuilderStubber {
   restore() {
     this.#stubber && !this.#stubber.restored && this.#stubber.restore();
     this.#stubber = undefined;
+
+    this.#command && !this.#command.restored && this.#command.restore();
+    this.#command = undefined;
   }
 }
 

--- a/test/mocked.ts
+++ b/test/mocked.ts
@@ -44,8 +44,7 @@ export class CommandBuilderStubber {
       combined.writeSync(opts.err);
     }
 
-    this.#command = mock.spy(CommandBuilder.prototype,
-      "command");
+    this.#command = mock.spy(CommandBuilder.prototype, "command");
 
     const result = new CommandResult(
       opts.code ?? 0,


### PR DESCRIPTION
Adds the optional --context flag to specify the kubectl config context